### PR TITLE
Add new option for target_frame

### DIFF
--- a/botsing-maven/README.md
+++ b/botsing-maven/README.md
@@ -1,16 +1,16 @@
 # Botsing Maven plugin
 
-Botsing Maven plugin let's you run [Botsing](https://github.com/STAMP-project/botsing) inside your Maven project as a Maven plugin.
+Botsing Maven plugin let's you run [Botsing](https://github.com/STAMP-project/botsing) as a Maven plugin.
 
 ## Install
 
-You can install it in your Maven local repository following this steps:
+You can install it in your Maven local repository with this command:
 
-1. From the project folder compile the project running `mvn compile`
+```
+mvn clean install
+```
 
-2. Install it in your Maven local repository running `mvn install`
-
-## Usage
+## Simple Usage
 
 If you have a Maven project you can run Botsing using Maven from the project folder with this command:
 
@@ -19,6 +19,44 @@ mvn eu.stamp-project:botsing-maven:botsing -Dcrash_log=ACC-474/ACC-474.log -Dtar
 ```
 
 * crash_log is the parameter to tell Botsing where is the log file to analyze.
-* target_frame is the parameter to tell Botsing how many lines of the log to replicate
+* target_frame is the parameter to tell Botsing how many lines of the stacktrace to replicate
 
 To have more information on the parameters that you can use, please refer to the [Botsing project](https://github.com/STAMP-project/botsing).
+
+## Dependencies options
+
+Dependencies are fundamental to run Botsing so it can reproduce the stacktrace. Botsing Maven plugin has three ways to specify where to find dependencies:
+
+1. from pom.xml
+1. specifiyng a Maven artifact
+1. from a folder
+
+### Dependencies from pom.xml
+
+Botsing Maven plugin will read the pom.xml in the current folder and find the dependencies specified in it. This will be the default behaviour if none else has been specified.
+
+### Dependencies from artifact
+
+Botsing Maven plugin will search in the Maven repository for this artifact and all the dependencies required.
+
+The command will be something like: 
+
+```
+mvn eu.stamp-project:botsing-maven:1.0.5-SNAPSHOT:botsing -Dcrash_log=ACC-474.log -Dmax_target_frame=2 -Dgroup_id=org.apache.commons -Dartifact_id=commons-collections4 -Dversion=4.0
+```
+
+### Dependencies from folder
+
+Botsing Maven plugin will search in the specified folder and gets all the libraries inside it. The command will be something like 
+
+```
+mvn eu.stamp-project:botsing-maven:botsing -Dcrash_log=ACC-474/ACC-474.log -Dtarget_frame=2 -Dproject_cp=lib
+```
+
+## Target frame options
+
+The target_frame lets you specify how many rows of the stacktrace Botsing has to reproduce. Botsing Maven plugin has three ways to specify it:
+
+1. directly using target_frame (e.g. -Dtarget_frame=2)
+1. specifying the maximum value (e.g. -Dmax_target_frame=2), in this case it will start from the maximum value provided and decrease it until a reproduction test have been found
+1. reading it from the maximum rows of the stacktrace, no parameter for the target frame should be provided

--- a/botsing-maven/README.md
+++ b/botsing-maven/README.md
@@ -42,7 +42,7 @@ Botsing Maven plugin will search in the Maven repository for this artifact and a
 The command will be something like: 
 
 ```
-mvn eu.stamp-project:botsing-maven:1.0.5-SNAPSHOT:botsing -Dcrash_log=ACC-474.log -Dmax_target_frame=2 -Dgroup_id=org.apache.commons -Dartifact_id=commons-collections4 -Dversion=4.0
+mvn eu.stamp-project:botsing-maven:botsing -Dcrash_log=ACC-474.log -Dmax_target_frame=2 -Dgroup_id=org.apache.commons -Dartifact_id=commons-collections4 -Dversion=4.0
 ```
 
 ### Dependencies from folder
@@ -60,3 +60,11 @@ The target_frame lets you specify how many rows of the stacktrace Botsing has to
 1. directly using target_frame (e.g. -Dtarget_frame=2)
 1. specifying the maximum value (e.g. -Dmax_target_frame=2), in this case it will start from the maximum value provided and decrease it until a reproduction test have been found
 1. reading it from the maximum rows of the stacktrace, no parameter for the target frame should be provided
+
+## Help
+
+To view a list of all the parameters that can be set use this command:
+
+```
+mvn eu.stamp-project:botsing-maven:help -Ddetail=true -Dgoal=botsing
+```

--- a/botsing-maven/src/main/java/eu/stamp/botsing/BotsingConfiguration.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/BotsingConfiguration.java
@@ -154,6 +154,7 @@ public class BotsingConfiguration {
 
 				if (decrease) {
 					value = value - 1;
+					properties.remove(i + 1);
 					properties.add(i + 1, (value) + "");
 				}
 
@@ -167,6 +168,7 @@ public class BotsingConfiguration {
 
 				if (decrease) {
 					value = value - 1;
+					properties.remove(i);
 					properties.add(i, "-D" + parameterName + "=" + value);
 				}
 

--- a/botsing-maven/src/main/java/eu/stamp/botsing/BotsingConfiguration.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/BotsingConfiguration.java
@@ -127,6 +127,11 @@ public class BotsingConfiguration {
 		return value;
 	}
 
+	public Integer getGlobalTimeout() {
+
+		return getOrDecreaseParameterValue("global_timeout", false);
+	}
+
 	public Integer getTargetFrame() {
 
 		return getOrDecreaseParameterValue(TARGET_FRAME_OPT, false);
@@ -158,7 +163,7 @@ public class BotsingConfiguration {
 
 				// parameter stored as "-DPARAM_NAME=PARAM_VALUE" (one string in the list)
 				int eqIndex = properties.get(i).indexOf("=");
-				value = Integer.parseInt(properties.get(i).substring(eqIndex));
+				value = Integer.parseInt(properties.get(i).substring(eqIndex + 1));
 
 				if (decrease) {
 					value = value - 1;

--- a/botsing-maven/src/main/java/eu/stamp/botsing/BotsingConfiguration.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/BotsingConfiguration.java
@@ -119,7 +119,7 @@ public class BotsingConfiguration {
 
 				// parameter stored as "-DPARAM_NAME=PARAM_VALUE" (one string in the list)
 				int eqIndex = properties.get(i).indexOf("=");
-				value = properties.get(i).substring(eqIndex);
+				value = properties.get(i).substring(eqIndex + 1);
 				break;
 			}
 		}

--- a/botsing-maven/src/main/java/eu/stamp/botsing/BotsingMojo.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/BotsingMojo.java
@@ -180,7 +180,7 @@ public class BotsingMojo extends AbstractMojo {
 		// TODO check properties
 
 		// set Botsing configuration
-		BotsingConfiguration configuration = new BotsingConfiguration(crashLog, getTargetFrame(), getDependencies(),
+		BotsingConfiguration configuration = new BotsingConfiguration(crashLog, targetFrame, getDependencies(),
 				population, searchBudget, globalTimeout, testDir, randomSeed, noRuntimeDependency, getLog());
 
 		// Start Botsing
@@ -195,7 +195,7 @@ public class BotsingMojo extends AbstractMojo {
 					new DefaultArtifact("eu.stamp-project", "botsing-reproduction", "", "jar", botsingVersion));
 
 			Integer actualTargetFrame = ProcessRunner.executeBotsing(project.getBasedir(), botsingReproductionJar,
-					configuration, maxTargetFrame, getLog());
+					configuration, getMaxTargetFrame(), getLog());
 
 			if (actualTargetFrame <= 0) {
 				throw new MojoFailureException("Failed to reproduce the stacktrace.");
@@ -211,12 +211,17 @@ public class BotsingMojo extends AbstractMojo {
 		getLog().info("Stopping Botsing");
 	}
 
-	private Integer getTargetFrame() throws MojoExecutionException {
+	/**
+	 * if maxTargetFrame and targetFrame are not set, set maxTargetFrame from crashLog rows
+	 * @return
+	 * @throws MojoExecutionException
+	 */
+	private Integer getMaxTargetFrame() throws MojoExecutionException {
 		if (targetFrame != null) {
-			return targetFrame;
+			return maxTargetFrame;
 
 		} else if (maxTargetFrame != null) {
-			return null;
+			return maxTargetFrame;
 
 		} else {
 			try {

--- a/botsing-maven/src/main/java/eu/stamp/botsing/BotsingMojo.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/BotsingMojo.java
@@ -94,7 +94,7 @@ public class BotsingMojo extends AbstractMojo {
 	 * the directory where the tests are generated with a default value of
 	 * `crashreproduction-tests`
 	 */
-	@Parameter(property = "test_dir")
+	@Parameter(property = "test_dir", defaultValue = "crashreproduction-tests")
 	private String testDir;
 
 	/**

--- a/botsing-maven/src/main/java/eu/stamp/botsing/BotsingMojo.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/BotsingMojo.java
@@ -355,6 +355,7 @@ public class BotsingMojo extends AbstractMojo {
 			buildingRequest = new DefaultProjectBuildingRequest();
 			buildingRequest.setProcessPlugins( false );
 			buildingRequest.setRepositorySession( repoSession );
+			buildingRequest.setRemoteRepositories(project.getRemoteArtifactRepositories());
 			org.apache.maven.artifact.Artifact artifact = new org.apache.maven.artifact.DefaultArtifact(groupId,
 					artifactId, version, "compile", extension, classifier, new DefaultArtifactHandler());
 

--- a/botsing-maven/src/main/java/eu/stamp/botsing/FileUtility.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/FileUtility.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
@@ -32,19 +33,16 @@ public class FileUtility {
 	 * @return true if the regex is found inside any file
 	 * @throws IOException
 	 */
-	public static boolean search(String folder, String regex) throws IOException {
+	public static boolean search(String folder, String regex, String[] extensions) throws IOException {
 
-		File fold = new File(folder);
+		Collection<File> files = FileUtils.listFiles(new File(folder), extensions, true);
 
-		for (File f : fold.listFiles()) {
+        for (File file : files) {
 
-			if (f.isDirectory()) {
-				search(f.getAbsolutePath(), regex);
-
-			} else if (searchInFile(f, regex)) {
+        	if (searchInFile(file, regex)) {
 				return true;
 			}
-		}
+        }
 
 		return false;
 	}

--- a/botsing-maven/src/main/java/eu/stamp/botsing/FileUtility.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/FileUtility.java
@@ -67,4 +67,9 @@ public class FileUtility {
 
 		return result;
 	}
+
+	public static void deleteFolder(String testDir) throws IOException {
+		FileUtils.deleteDirectory(new File(testDir));
+
+	}
 }

--- a/botsing-maven/src/main/java/eu/stamp/botsing/FileUtility.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/FileUtility.java
@@ -2,11 +2,27 @@ package eu.stamp.botsing;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 
 public class FileUtility {
+
+	/**
+	 * @param file
+	 * @return number of rows in the file
+	 * @throws IOException
+	 */
+	public static long getRowNumber(String file) throws IOException {
+
+		try ( Stream<String> lines = Files.lines(Paths.get(file), Charset.defaultCharset()) ) {
+			return lines.count();
+		}
+	}
 
 	/**
 	 * Search inside the files of the folder and in subfolders for the regex

--- a/botsing-maven/src/main/java/eu/stamp/botsing/FileUtility.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/FileUtility.java
@@ -9,7 +9,7 @@ import org.apache.commons.io.LineIterator;
 public class FileUtility {
 
 	/**
-	 * Search inside the files of the folder for the regex
+	 * Search inside the files of the folder and in subfolders for the regex
 	 *
 	 * @param folder
 	 * @param regex
@@ -22,7 +22,10 @@ public class FileUtility {
 
 		for (File f : fold.listFiles()) {
 
-			if (searchInFile(f, regex)) {
+			if (f.isDirectory()) {
+				search(f.getAbsolutePath(), regex);
+
+			} else if (searchInFile(f, regex)) {
 				return true;
 			}
 		}

--- a/botsing-maven/src/main/java/eu/stamp/botsing/ProcessRunner.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/ProcessRunner.java
@@ -33,12 +33,14 @@ public class ProcessRunner {
 
 				success = ProcessRunner.executeBotsing(basedir, botsingReproductionJar, configuration.getProperties(), log);
 
-				// check that the generated test does not contains "EvoSuite did not generate any tests"
-				if (success && Paths.get(configuration.getTestDir()).toFile().list().length > 0) {
+				// stop only if the generated test does not contains "EvoSuite did not generate any tests"
+				if (success) {
 
-					boolean emptyTest = FileUtility.search(configuration.getTestDir(), ".*EvoSuite did not generate any tests.*");
-					if (!emptyTest) {
+					if (hasReproductionTestBeenGenerated(configuration)) {
 						break;
+
+					} else {
+						success = false;
 					}
 				}
 
@@ -52,6 +54,28 @@ public class ProcessRunner {
 
 		} else {
 			return -1;
+		}
+	}
+
+	private static boolean hasReproductionTestBeenGenerated(BotsingConfiguration configuration) throws IOException {
+
+		if (Paths.get(configuration.getTestDir()).toFile().list().length > 0) {
+
+			boolean emptyTest = FileUtility.search(configuration.getTestDir(),
+					".*EvoSuite did not generate any tests.*", new String[] { "java" });
+
+			if (!emptyTest) {
+				// generated test are NOT empty
+				return true;
+
+			} else {
+				// generated test are empty
+				return false;
+			}
+
+		} else {
+			// nothing has been generated
+			return false;
 		}
 	}
 

--- a/botsing-maven/src/main/java/eu/stamp/botsing/ProcessRunner.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/ProcessRunner.java
@@ -29,6 +29,8 @@ public class ProcessRunner {
 			while (!success || targetFrame == 0) {
 
 				log.info("Running Botsing with frame " + targetFrame);
+				configuration.addTargetFrame(targetFrame);
+
 				success = ProcessRunner.executeBotsing(basedir, botsingReproductionJar, configuration.getProperties(), log);
 
 				// check that the generated test does not contains "EvoSuite did not generate any tests"

--- a/botsing-maven/src/main/java/eu/stamp/botsing/ProcessRunner.java
+++ b/botsing-maven/src/main/java/eu/stamp/botsing/ProcessRunner.java
@@ -36,6 +36,10 @@ public class ProcessRunner {
 				log.info("Running Botsing with frame " + targetFrame);
 				configuration.addTargetFrame(targetFrame);
 
+				// clean output folder
+				FileUtility.deleteFolder(configuration.getTestDir());
+
+				// execute Botsing
 				success = ProcessRunner.executeBotsing(basedir, botsingReproductionJar,
 						new Long(configuration.getGlobalTimeout()), configuration.getProperties(), log);
 
@@ -47,8 +51,6 @@ public class ProcessRunner {
 
 					} else {
 						success = false;
-						// clean output folder
-						FileUtility.deleteFolder(configuration.getTestDir());
 					}
 				}
 

--- a/botsing-maven/src/test/java/eu/stamp/botsing/FileUtilityTest.java
+++ b/botsing-maven/src/test/java/eu/stamp/botsing/FileUtilityTest.java
@@ -51,8 +51,6 @@ public class FileUtilityTest {
 		File javaTestFile = new File(folderWithTest, "javaTestFile.java");
 		FileUtils.writeStringToFile(javaTestFile, javaTest, "UTF-8");
 
-		System.out.println("New file '" + javaTestFile.getAbsolutePath() + "' created.");
-
 		assertFalse(FileUtility.search(folderWithTest.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
 	}
 
@@ -76,18 +74,13 @@ public class FileUtilityTest {
 		File emptyJavaTestFile = new File(folderWithEmptyTest, "emptyJavaTestFile.java");
 		FileUtils.writeStringToFile(emptyJavaTestFile, emptyJavaTest, "UTF-8");
 
-		System.out.println("New file '" + emptyJavaTestFile.getAbsolutePath() + "' created.");
-
 		assertTrue(FileUtility.search(folderWithEmptyTest.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
 	}
 
 	@Test
 	public void searchInEmptyFolder() throws IOException {
 
-		// Write empty Java Test File
 		File emptyFolder = tmpFolder.newFolder();
-
-		System.out.println("Empty folder '" + emptyFolder.getAbsolutePath() + "' created.");
 
 		assertFalse(FileUtility.search(emptyFolder.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
 	}
@@ -107,13 +100,24 @@ public class FileUtilityTest {
 				"  }\n" +
 				"}";
 
-		// Write empty Java Test File
 		File subfolder = tmpFolder.newFolder("eu", "stamp");
 		File emptyJavaTestFile = new File(subfolder, "emptyJavaTestFile.java");
 		FileUtils.writeStringToFile(emptyJavaTestFile, emptyJavaTest, "UTF-8");
 
-		System.out.println("New file '" + emptyJavaTestFile.getAbsolutePath() + "' created.");
-
 		assertTrue(FileUtility.search(subfolder.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
+	}
+
+	@Test
+	public void getRowNumberTest() throws IOException {
+
+		String stacktrace = "java.lang.IndexOutOfBoundsException: Index: 3, Size: 2\n" +
+				"        at org.apache.commons.collections4.map.ListOrderedMap.put(ListOrderedMap.java:459)\n" +
+				"        at org.apache.commons.collections4.map.ListOrderedMap.putAll(ListOrderedMap.java:251)\n";
+
+		File folder = tmpFolder.newFolder();
+		File logFile = new File(folder, "logFile.java");
+		FileUtils.writeStringToFile(logFile, stacktrace, "UTF-8");
+
+		assertTrue(FileUtility.getRowNumber(logFile.getAbsolutePath()) == 3);
 	}
 }

--- a/botsing-maven/src/test/java/eu/stamp/botsing/FileUtilityTest.java
+++ b/botsing-maven/src/test/java/eu/stamp/botsing/FileUtilityTest.java
@@ -91,4 +91,29 @@ public class FileUtilityTest {
 
 		assertFalse(FileUtility.search(emptyFolder.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
 	}
+
+	@Test
+	public void searchShouldFindEmptyRegexInSubFolders() throws IOException {
+
+		String emptyJavaTest = "package org.apache.commons.lang3;\n" +
+				"\n" +
+				"import org.junit.Test;\n" +
+				"import static org.junit.Assert.*;\n" +
+				"\n" +
+				"public class SerializationUtils_ESTest {\n" +
+				"  @Test\n" +
+				"  public void notGeneratedAnyTest() {\n" +
+				"    // EvoSuite did not generate any tests\n" +
+				"  }\n" +
+				"}";
+
+		// Write empty Java Test File
+		File subfolder = tmpFolder.newFolder("eu", "stamp");
+		File emptyJavaTestFile = new File(subfolder, "emptyJavaTestFile.java");
+		FileUtils.writeStringToFile(emptyJavaTestFile, emptyJavaTest, "UTF-8");
+
+		System.out.println("New file '" + emptyJavaTestFile.getAbsolutePath() + "' created.");
+
+		assertTrue(FileUtility.search(subfolder.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
+	}
 }

--- a/botsing-maven/src/test/java/eu/stamp/botsing/FileUtilityTest.java
+++ b/botsing-maven/src/test/java/eu/stamp/botsing/FileUtilityTest.java
@@ -51,7 +51,7 @@ public class FileUtilityTest {
 		File javaTestFile = new File(folderWithTest, "javaTestFile.java");
 		FileUtils.writeStringToFile(javaTestFile, javaTest, "UTF-8");
 
-		assertFalse(FileUtility.search(folderWithTest.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
+		assertFalse(FileUtility.search(folderWithTest.getAbsolutePath(), ".*EvoSuite did not generate any tests.*", new String[] {"java"}));
 	}
 
 	@Test
@@ -74,7 +74,7 @@ public class FileUtilityTest {
 		File emptyJavaTestFile = new File(folderWithEmptyTest, "emptyJavaTestFile.java");
 		FileUtils.writeStringToFile(emptyJavaTestFile, emptyJavaTest, "UTF-8");
 
-		assertTrue(FileUtility.search(folderWithEmptyTest.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
+		assertTrue(FileUtility.search(folderWithEmptyTest.getAbsolutePath(), ".*EvoSuite did not generate any tests.*", new String[] {"java"}));
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class FileUtilityTest {
 
 		File emptyFolder = tmpFolder.newFolder();
 
-		assertFalse(FileUtility.search(emptyFolder.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
+		assertFalse(FileUtility.search(emptyFolder.getAbsolutePath(), ".*EvoSuite did not generate any tests.*", new String[] {"java"}));
 	}
 
 	@Test
@@ -104,7 +104,7 @@ public class FileUtilityTest {
 		File emptyJavaTestFile = new File(subfolder, "emptyJavaTestFile.java");
 		FileUtils.writeStringToFile(emptyJavaTestFile, emptyJavaTest, "UTF-8");
 
-		assertTrue(FileUtility.search(subfolder.getAbsolutePath(), ".*EvoSuite did not generate any tests.*"));
+		assertTrue(FileUtility.search(subfolder.getAbsolutePath(), ".*EvoSuite did not generate any tests.*", new String[] {"java"}));
 	}
 
 	@Test
@@ -120,4 +120,5 @@ public class FileUtilityTest {
 
 		assertTrue(FileUtility.getRowNumber(logFile.getAbsolutePath()) == 3);
 	}
+
 }


### PR DESCRIPTION
Target frame options: 
1. directly using target_frame (e.g. -Dtarget_frame=2)
2. specifying the maximum value (e.g. -Dmax_target_frame=2), in this case it will start from the maximum value provided and decrease it until a reproduction test have been found
3. reading it from the maximum rows of the stacktrace, no parameter for the target frame should be provided