### PR TITLE
Fixed STAMP-project/botsing#109.

### DIFF
--- a/botsing-reproduction/src/main/java/eu/stamp/botsing/fitnessfunction/IntegrationTestingFF.java
+++ b/botsing-reproduction/src/main/java/eu/stamp/botsing/fitnessfunction/IntegrationTestingFF.java
@@ -60,7 +60,16 @@ public class IntegrationTestingFF extends TestFitnessFunction {
             if(resultException.getStackTrace().length == 0 ){
                 continue;
             }
-            String crashingClass = resultException.getStackTrace()[0].getClassName();
+
+            int frame = -1;
+            String crashingClass;
+            do {
+                crashingClass = resultException.getStackTrace()[++frame].getClassName();
+            }
+            while (frame < resultException.getStackTrace().length && (crashingClass.startsWith("java") || crashingClass.startsWith("javax")));
+            if (frame == resultException.getStackTrace().length)
+                continue;
+
             int crashingLine = resultException.getStackTrace()[0].getLineNumber();
             if(targetCrash.getFrame(1).getLineNumber() != crashingLine || !targetCrash.getFrame(1).getClassName().equals(crashingClass)){
                 continue;


### PR DESCRIPTION
In `exceptionCoverage()` of `IntegrationTestingFF`, if the highest frame of the `resultException` is from jdk, falls back to a lower frame to compare with the `targetCrash`
Because in [JCrashPack](https://github.com/STAMP-project/JCrashPack), frames of jdk are left out in the log files.